### PR TITLE
feat:增加设备连接数

### DIFF
--- a/cmd/padavan_exporter/main.go
+++ b/cmd/padavan_exporter/main.go
@@ -49,6 +49,7 @@ func main() {
 	reg.MustRegister(collector.NewNetDevController(sc))
 	reg.MustRegister(collector.NewCpuCollector(sc))
 	reg.MustRegister(collector.NewMemoryCollector(sc))
+	reg.MustRegister(collector.NewNetconnCollector(sc))
 
 	gatherers := prometheus.Gatherers{reg}
 	h := promhttp.HandlerFor(gatherers, promhttp.HandlerOpts{

--- a/collector/netconn.go
+++ b/collector/netconn.go
@@ -1,0 +1,138 @@
+package collector
+
+import (
+	"bufio"
+	"fmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"golang.org/x/crypto/ssh"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+/**
+ * @Author: 南宫乘风
+ * @Description:
+ * @File:  netconn.go
+ * @Email: 1794748404@qq.com
+ * @Date: 2024-07-08 10:10
+ */
+const (
+	namespace         = "node"
+	netStatsSubsystem = "netstat"
+)
+
+var (
+	netStatFields = kingpin.Flag(
+		"collector.netstat.fields",
+		"Regexp of fields to return for netstat collector.",
+	).Default(
+		"^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(Listen.*|Syncookies.*|TCPSynRetrans|TCPTimeouts|TCPOFOQueue)|Tcp_(ActiveOpens|InSegs|OutSegs|OutRsts|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts|RcvbufErrors|SndbufErrors))$",
+	).String()
+)
+
+type NetconnCollector struct {
+	metrics      map[string]*prometheus.Desc // Stores metric descriptions
+	sc           *ssh.Client                 // SSH client for remote data collection
+	fieldPattern *regexp.Regexp              // Regex for matching field names
+}
+
+func (c *NetconnCollector) Describe(ch chan<- *prometheus.Desc) {
+	// Metrics are created during Collect
+}
+
+func (c *NetconnCollector) Collect(ch chan<- prometheus.Metric) {
+	netStats := parseNetStats(mustGetContent(c.sc, "/proc/net/netstat"))
+	snmpStats := parseNetStats(mustGetContent(c.sc, "/proc/net/snmp"))
+	snmp6Stats := parseSNMP6Stats(mustGetContent(c.sc, "/proc/net/snmp6"))
+
+	// Merge snmpStats and snmp6Stats into netStats
+	for k, v := range snmpStats {
+		netStats[k] = v
+	}
+	for k, v := range snmp6Stats {
+		netStats[k] = v
+	}
+
+	for protocol, protocolStats := range netStats {
+		for name, value := range protocolStats {
+			key := protocol + "_" + name
+			if !c.fieldPattern.MatchString(key) {
+				continue
+			}
+
+			v, err := strconv.ParseFloat(value, 64)
+			if err != nil {
+				fmt.Printf("Invalid value in netstats: %v, error: %v\n", value, err)
+				continue
+			}
+
+			desc := prometheus.NewDesc(
+				prometheus.BuildFQName(namespace, netStatsSubsystem, key),
+				fmt.Sprintf("Statistic %s.", key),
+				nil, nil,
+			)
+
+			ch <- prometheus.MustNewConstMetric(desc, prometheus.UntypedValue, v)
+		}
+	}
+}
+
+func parseNetStats(content string) map[string]map[string]string {
+	// 将字符串内容转换为 io.Reader
+	reader := strings.NewReader(content)
+	netStats := make(map[string]map[string]string)
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		nameParts := strings.Split(scanner.Text(), " ")
+		if !scanner.Scan() {
+			break
+		}
+		valueParts := strings.Split(scanner.Text(), " ")
+		protocol := strings.TrimSuffix(nameParts[0], ":")
+		netStats[protocol] = make(map[string]string)
+		if len(nameParts) != len(valueParts) {
+			continue
+		}
+		for i := 1; i < len(nameParts); i++ {
+			netStats[protocol][nameParts[i]] = valueParts[i]
+		}
+	}
+
+	return netStats
+}
+
+func parseSNMP6Stats(content string) map[string]map[string]string {
+	reader := strings.NewReader(content)
+
+	netStats := make(map[string]map[string]string)
+	scanner := bufio.NewScanner(reader)
+
+	for scanner.Scan() {
+		stat := strings.Fields(scanner.Text())
+		if len(stat) < 2 {
+			continue
+		}
+		if sixIndex := strings.Index(stat[0], "6"); sixIndex != -1 {
+			protocol := stat[0][:sixIndex+1]
+			name := stat[0][sixIndex+1:]
+			if _, present := netStats[protocol]; !present {
+				netStats[protocol] = make(map[string]string)
+			}
+			netStats[protocol][name] = stat[1]
+		}
+	}
+
+	return netStats
+}
+
+func NewNetconnCollector(sc *ssh.Client) *NetconnCollector {
+	pattern := regexp.MustCompile(*netStatFields)
+	return &NetconnCollector{
+		sc:           sc,
+		metrics:      map[string]*prometheus.Desc{},
+		fieldPattern: pattern,
+	}
+}


### PR DESCRIPTION
仿照node_exporter 增加设备连接数，主要获取以下三个文件内容进行解析
```go
	netStats := parseNetStats(mustGetContent(c.sc, "/proc/net/netstat"))
	snmpStats := parseNetStats(mustGetContent(c.sc, "/proc/net/snmp"))
	snmp6Stats := parseSNMP6Stats(mustGetContent(c.sc, "/proc/net/snmp6"))
```
输出的 指标 如下
```bash
node_netstat_Icmp6_InErrors 0
node_netstat_Icmp6_InMsgs 0
node_netstat_Icmp6_OutMsgs 0
node_netstat_Icmp_InErrors 0
node_netstat_Icmp_InMsgs 29
node_netstat_Icmp_OutMsgs 23
node_netstat_Ip6_InOctets 120518
node_netstat_Ip6_OutOctets 0
node_netstat_IpExt_InOctets 4.1749801e+07
node_netstat_IpExt_OutOctets 4.1061686e+07
node_netstat_Ip_Forwarding 1
node_netstat_TcpExt_ListenDrops 0
node_netstat_TcpExt_ListenOverflows 0
node_netstat_TcpExt_SyncookiesFailed 0
node_netstat_TcpExt_SyncookiesRecv 0
node_netstat_TcpExt_SyncookiesSent 0
node_netstat_TcpExt_TCPTimeouts 1
node_netstat_Tcp_ActiveOpens 17
node_netstat_Tcp_CurrEstab 2
node_netstat_Tcp_InErrs 0
node_netstat_Tcp_InSegs 330
node_netstat_Tcp_OutRsts 10
node_netstat_Tcp_OutSegs 297
node_netstat_Tcp_PassiveOpens 3
node_netstat_Tcp_RetransSegs 4
node_netstat_Udp6_InDatagrams 0
node_netstat_Udp6_InErrors 0
node_netstat_Udp6_NoPorts 0
node_netstat_Udp6_OutDatagrams 0
node_netstat_Udp6_RcvbufErrors 0
node_netstat_Udp6_SndbufErrors 0
node_netstat_Udp_InDatagrams 548
node_netstat_Udp_InErrors 0
node_netstat_Udp_NoPorts 0
node_netstat_Udp_OutDatagrams 581
node_netstat_Udp_RcvbufErrors 0
node_netstat_Udp_SndbufErrors 0
```
![image](https://github.com/Bpazy/padavan_exporter/assets/46562911/b5d1ce69-25b0-4826-ad2b-dc03d9ac8bc0)
